### PR TITLE
Add ConnectionServer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 Contains case programs of M5Stack Atom-JoyStick.
 Example sketches are available in the `examples` directory. The `ConnectionServer` sketch runs a simple HTTP server that exposes joystick values over Wi-Fi.
 
+## 操作用に参考になる主なファイル
+
+- **ライブラリAPI** (`src/AtomJoyStick.*`)
+  - ジョイスティックやボタンの値を取得するための関数が AtomJoyStick クラスとして定義されています。初期化 (begin) や各軸／ボタンの読み取り関数がここにあります。
+- **ジョイスティックの基本読み取り** (`examples/GetValue/GetValue.ino`)
+  - デバイスの初期化から各ジョイスティック軸・バッテリー情報の取得までをシリアルへ出力する最小構成のサンプルです。
+- **HTTPサーバーで値を提供** (`examples/ConnectionServer/ConnectionServer.ino`)
+  - M5AtomS3 をアクセスポイントとして起動し、/values でジョイスティックのADC値を JSON で返す簡易Webサーバーを実装しています。
+- **Wi‑Fi設定用Webインターフェース** (`examples/StampFlyController/lib/M5AtomS3/examples/Advanced/WIFI/WiFiSetting/WiFiSetting.ino`)
+  - アクセスポイントを立ち上げ、ブラウザからSSIDとパスワードを入力して保存・再起動する仕組みを示しています。
+- **MQTTによる遠隔通信** (`examples/StampFlyController/lib/M5AtomS3/examples/Advanced/MQTT/MQTT.ino`)
+  - Wi‑Fi 接続後に MQTT ブローカーへ接続し、メッセージを Publish/Subscribe する方法を示すサンプルです。
+
 ## License
 
 [Atom-JoyStick - MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Contains case programs of M5Stack Atom-JoyStick.
-
+Example sketches are available in the `examples` directory. The `ConnectionServer` sketch runs a simple HTTP server that exposes joystick values over Wi-Fi.
 
 ## License
 

--- a/examples/ConnectionServer/ConnectionServer.ino
+++ b/examples/ConnectionServer/ConnectionServer.ino
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2024 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <M5AtomS3.h>
+#include <WiFi.h>
+#include "WebServer.h"
+#include "AtomJoyStick.h"
+
+const char* apSSID = "M5JOY";           // Access point SSID
+const char* apPassword = "";            // No password
+
+WebServer server(80);
+AtomJoyStick joystick;
+
+void handleRoot() {
+  String s = "<html><body>";
+  s += "<h1>Atom JoyStick</h1>";
+  s += "<p><a href=\"/values\">Read Values</a></p>";
+  s += "</body></html>";
+  server.send(200, "text/html", s);
+}
+
+void handleValues() {
+  char buf[128];
+  snprintf(buf, sizeof(buf),
+           "{\"joy1_x\":%d,\"joy1_y\":%d,\"joy2_x\":%d,\"joy2_y\":%d}",
+           joystick.getJoy1ADCValueX(_12bit),
+           joystick.getJoy1ADCValueY(_12bit),
+           joystick.getJoy2ADCValueX(_12bit),
+           joystick.getJoy2ADCValueY(_12bit));
+  server.send(200, "application/json", buf);
+}
+
+void setup() {
+  M5.begin();
+  joystick.begin(&Wire, ATOM_JOYSTICK_ADDR, 38, 39, 400000U);
+
+  WiFi.softAP(apSSID, apPassword);
+  IPAddress ip = WiFi.softAPIP();
+  M5.Lcd.printf("AP: %s\nIP: %s\n", apSSID, ip.toString().c_str());
+
+  server.on("/", handleRoot);
+  server.on("/values", handleValues);
+  server.begin();
+}
+
+void loop() {
+  server.handleClient();
+  delay(2);
+}


### PR DESCRIPTION
## Summary
- add `ConnectionServer` example showing a Wi-Fi HTTP server
- mention new example in README

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68622bc8fb50832091573f7beb655179